### PR TITLE
update dust test raise equals success level

### DIFF
--- a/contracts/Trust.sol
+++ b/contracts/Trust.sol
@@ -239,10 +239,10 @@ contract Trust {
             // SO success balance - (seed pay + token pay) >= 0
             // SO final balance - (seed pay + token pay) >= 0
             //
-            // Implied is the remainder of _finalBalance as redeemInit
+            // Implied is the remainder of _distributableBalance as redeemInit
             // This will be transferred to the token holders below.
             if (redeemInit >= _poolDust) {
-                _creatorPay = _finalBalance.sub(_seederPay.add(redeemInit));
+                _creatorPay = _distributableBalance.sub(_seederPay.add(redeemInit));
             }
             // In any case where redeemInit is less than dust we just split everything we have between the creator and seeder.
             // If this fails that means the seeder pay is bigger than the distributable balance, which is an extreme edge case.
@@ -258,8 +258,8 @@ contract Trust {
             // Due to pool dust it is possible the final balance is less than the reserve init.
             // If we don't take the min then we will attempt to transfer more than exists and brick the contract.
             //
-            // Implied if _finalBalance > reserve_init is the remainder goes to token holders below.
-            _seederPay = _seedInit.min(_finalBalance);
+            // Implied if _distributableBalance > reserve_init is the remainder goes to token holders below.
+            _seederPay = _seedInit.min(_distributableBalance);
         }
 
         if (_creatorPay > 0) {

--- a/test/Trust.sol.ts
+++ b/test/Trust.sol.ts
@@ -359,7 +359,7 @@ describe("Trust", async function () {
 
     const startBlock = await ethers.provider.getBlockNumber()
 
-    assert((await token.unblockBlock()).isZero(), "token unblock block was set in trust startRaise")
+    assert((await token.unblockBlock()).isZero(), "token unblock block was wrongly set in trust startRaise")
 
     while ((await ethers.provider.getBlockNumber()) < (startBlock + raiseDuration - 1)) {
       await reserve.transfer(signers[3].address, 1)


### PR DESCRIPTION
Updates test where reserve raised in balancer pool is exactly equal to the raise success level. This currently fails as dust (`currentBPoolBalance * 1e-7`) is left behind in the balancer pool.

This test should pass if a small amount of reserve is available on the Trust when the raise is ended, to cover the dust. This amount is roughly `successLevel * 1e-7`

I would suggest a little more than that in case of rounding errors.