### PR TITLE
Adding the literalContent option

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,6 +23,9 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 100000,
           },
+          metadata: {
+            useLiteralContent: true,
+          },
         },
       },
       {


### PR DESCRIPTION
- This edit the hardhat.config to add the metadata option "useLiteralContent" only in the 0.8.10 compiler, This will help to match the metadata hash at the end of the bytecode.