### PR TITLE
vesting

### DIFF
--- a/contracts/claim/EmissionsERC20.sol
+++ b/contracts/claim/EmissionsERC20.sol
@@ -248,7 +248,7 @@ contract EmissionsERC20 is
         if (token_ == address(0)) {
             _mint(claimant_, amount_);
         } else {
-            IERC20(token_).safeTransfer(msg.sender, amount_);
+            IERC20(token_).safeTransfer(claimant_, amount_);
         }
 
         // Record the current block as the latest claim.


### PR DESCRIPTION
changes emissions contract so that instead of returning a single value which is the amount of itself to mint, two values are returned

the first value if zero will behave as it always has by minting itself, if non-zero the contract will interpret the first value as a token address and attempt to send that token rather than mint itself

this provides a simple way to vest tokens according to a schedule, the contract has no knowledge/opinion on how the tokens get in the contract in the first place, if they run out the transfer will simply fail until the contract is topped up