### PR TITLE
add eager if

### DIFF
--- a/test/VM/LogicOps.sol.ts
+++ b/test/VM/LogicOps.sol.ts
@@ -24,6 +24,79 @@ const enum Opcode {
 const isTruthy = (vmValue: BigNumber) => vmValue.eq(1);
 
 describe("LogicOps", async function () {
+  it("should perform ternary 'eager if' operation on 3 values on the stack", async () => {
+    this.timeout(0);
+
+    const logicFactory = await ethers.getContractFactory("LogicTest");
+
+    const constants = [0, 1, 2, 3];
+
+    const v0 = op(Opcode.VAL, 0);
+    const v1 = op(Opcode.VAL, 1);
+    const v2 = op(Opcode.VAL, 2);
+    const v3 = op(Opcode.VAL, 3);
+
+    // prettier-ignore
+    const source0 = concat([
+      // 1 ? 2 : 3
+      v1,
+      v2,
+      v3,
+      op(Opcode.EAGER_IF),
+    ]);
+
+    const logic0 = (await logicFactory.deploy({
+      sources: [source0],
+      constants,
+      argumentsLength: 0,
+      stackLength: 3,
+    })) as LogicTest & Contract;
+
+    const result0 = await logic0.run();
+
+    assert(result0.eq(2), `returned wrong value from eager if, got ${result0}`);
+
+    // prettier-ignore
+    const source1 = concat([
+      // 2 ? 2 : 3
+      v2,
+      v2,
+      v3,
+      op(Opcode.EAGER_IF),
+    ]);
+
+    const logic1 = (await logicFactory.deploy({
+      sources: [source1],
+      constants,
+      argumentsLength: 0,
+      stackLength: 3,
+    })) as LogicTest & Contract;
+
+    const result1 = await logic1.run();
+
+    assert(result1.eq(2), `returned wrong value from eager if, got ${result1}`);
+
+    // prettier-ignore
+    const source2 = concat([
+      // 2 ? 2 : 3
+      v0,
+      v2,
+      v3,
+      op(Opcode.EAGER_IF),
+    ]);
+
+    const logic2 = (await logicFactory.deploy({
+      sources: [source2],
+      constants,
+      argumentsLength: 0,
+      stackLength: 3,
+    })) as LogicTest & Contract;
+
+    const result2 = await logic2.run();
+
+    assert(result2.eq(3), `returned wrong value from eager if, got ${result2}`);
+  });
+
   it("should check that value is greater than another value", async () => {
     this.timeout(0);
 
@@ -59,7 +132,7 @@ describe("LogicOps", async function () {
     const logic1 = (await logicFactory.deploy({
       sources: [source1],
       constants,
-      argumentsLength: 1,
+      argumentsLength: 0,
       stackLength: 3,
     })) as LogicTest & Contract;
 
@@ -103,7 +176,7 @@ describe("LogicOps", async function () {
     const logic1 = (await logicFactory.deploy({
       sources: [source1],
       constants,
-      argumentsLength: 1,
+      argumentsLength: 0,
       stackLength: 3,
     })) as LogicTest & Contract;
 
@@ -147,7 +220,7 @@ describe("LogicOps", async function () {
     const logic1 = (await logicFactory.deploy({
       sources: [source1],
       constants,
-      argumentsLength: 1,
+      argumentsLength: 0,
       stackLength: 3,
     })) as LogicTest & Contract;
 
@@ -189,7 +262,7 @@ describe("LogicOps", async function () {
     const logic1 = (await logicFactory.deploy({
       sources: [source1],
       constants,
-      argumentsLength: 1,
+      argumentsLength: 0,
       stackLength: 3,
     })) as LogicTest & Contract;
 

--- a/test/VM/LogicOps.sol.ts
+++ b/test/VM/LogicOps.sol.ts
@@ -15,6 +15,7 @@ const enum Opcode {
   DUP,
   ZIPMAP,
   IS_ZERO,
+  EAGER_IF,
   EQUAL_TO,
   LESS_THAN,
   GREATER_THAN,


### PR DESCRIPTION
adds an eager if to logic ops

collapses top 3 values on stack to 1 value

if first value is `0` then third value is used, else second value is used

e.g.

```
1 2 3 EAGER_IF // 2
2 2 3 EAGER_IF // 2
0 2 3 EAGER_IF // 3
```

so called "eager" because everything must be fully eagerly evaluated (unlike conditional form of skip that operates on the source code itself rather than the stack, and so can "lazily" avoid execution)

mostly useful because it's simply/easy to explain and if BOTH the possible values are cheap to calculate then why not?
