### PR TITLE
lock solidity versions to =0.8.10

### DIFF
--- a/contracts/claim/EmissionsERC20.sol
+++ b/contracts/claim/EmissionsERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "../tier/libraries/TierConstants.sol";
 import {ERC20Config} from "../erc20/ERC20Config.sol";

--- a/contracts/claim/EmissionsERC20Factory.sol
+++ b/contracts/claim/EmissionsERC20Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Factory} from "../factory/Factory.sol";
 import {EmissionsERC20, EmissionsERC20Config} from "./EmissionsERC20.sol";

--- a/contracts/claim/IClaim.sol
+++ b/contracts/claim/IClaim.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 /// @title IClaim
 /// @notice Embodies the idea of processing a claim for some kind of reward.

--- a/contracts/cooldown/Cooldown.sol
+++ b/contracts/cooldown/Cooldown.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// @title Cooldown
 /// @notice `Cooldown` is a base contract that rate limits functions on

--- a/contracts/erc20/ERC20Config.sol
+++ b/contracts/erc20/ERC20Config.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// Constructor config for standard Open Zeppelin ERC20.
 struct ERC20Config {

--- a/contracts/erc20/ERC20Pull.sol
+++ b/contracts/erc20/ERC20Pull.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/erc20/ERC20Redeem.sol
+++ b/contracts/erc20/ERC20Redeem.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/escrow/BPoolFeeEscrow.sol
+++ b/contracts/escrow/BPoolFeeEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {IBPool} from "../pool/IBPool.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/escrow/RedeemableERC20ClaimEscrow.sol
+++ b/contracts/escrow/RedeemableERC20ClaimEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {RedeemableERC20} from "../redeemableERC20/RedeemableERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";

--- a/contracts/escrow/TrustEscrow.sol
+++ b/contracts/escrow/TrustEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Trust, DistributionStatus} from "../trust/Trust.sol";
 

--- a/contracts/factory/Factory.sol
+++ b/contracts/factory/Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {IFactory} from "./IFactory.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/factory/IFactory.sol
+++ b/contracts/factory/IFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 interface IFactory {
     /// Whenever a new child contract is deployed, a `NewChild` event

--- a/contracts/math/SaturatingMath.sol
+++ b/contracts/math/SaturatingMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// @title SaturatingMath
 /// @notice Sometimes we neither want math operations to error nor wrap around

--- a/contracts/phased/Phased.sol
+++ b/contracts/phased/Phased.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// @title Phased
 /// @notice `Phased` is an abstract contract that defines up to `9` phases that

--- a/contracts/pool/IBPool.sol
+++ b/contracts/pool/IBPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 /// Mirrors the Balancer `BPool` functions relevant to Rain.
 /// Much of the Balancer contract is elided intentionally.

--- a/contracts/pool/IBalancerConstants.sol
+++ b/contracts/pool/IBalancerConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 // Mirrors all the constants from Balancer `configurable-rights-pool` repo.
 // As we do not include balancer contracts as a dependency, we need to ensure

--- a/contracts/pool/ICRPFactory.sol
+++ b/contracts/pool/ICRPFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 import {PoolParams} from "./IConfigurableRightsPool.sol";
 import {Rights} from "./IRightsManager.sol";

--- a/contracts/pool/IConfigurableRightsPool.sol
+++ b/contracts/pool/IConfigurableRightsPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 /// Mirrors the `PoolParams` struct normally internal to a Balancer
 /// `ConfigurableRightsPool`.

--- a/contracts/pool/IRightsManager.sol
+++ b/contracts/pool/IRightsManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 // Mirrors `Rights` from Balancer `configurable-rights-pool` repo.
 // As we do not include balancer contracts as a dependency, we need to ensure

--- a/contracts/redeemableERC20/RedeemableERC20.sol
+++ b/contracts/redeemableERC20/RedeemableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ERC20Config} from "../erc20/ERC20Config.sol";
 import "../erc20/ERC20Redeem.sol";

--- a/contracts/redeemableERC20/RedeemableERC20Factory.sol
+++ b/contracts/redeemableERC20/RedeemableERC20Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Factory} from "../factory/Factory.sol";
 import {RedeemableERC20, RedeemableERC20Config} from "./RedeemableERC20.sol";

--- a/contracts/seed/SeedERC20.sol
+++ b/contracts/seed/SeedERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ERC20Config} from "../erc20/ERC20Config.sol";
 

--- a/contracts/seed/SeedERC20Factory.sol
+++ b/contracts/seed/SeedERC20Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Factory} from "../factory/Factory.sol";
 import {SeedERC20, SeedERC20Config} from "./SeedERC20.sol";

--- a/contracts/sstore2/SSTORE2.sol
+++ b/contracts/sstore2/SSTORE2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "./utils/Bytecode.sol";
 

--- a/contracts/sstore2/utils/Bytecode.sol
+++ b/contracts/sstore2/utils/Bytecode.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 library Bytecode {
     error InvalidCodeAtRange(uint256 _size, uint256 _start, uint256 _end);

--- a/contracts/test/CalculatorTest.sol
+++ b/contracts/test/CalculatorTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {RainVM, State} from "../vm/RainVM.sol";
 import {VMState, StateConfig} from "../vm/libraries/VMState.sol";

--- a/contracts/test/RedeemableERC20Reentrant.sol
+++ b/contracts/test/RedeemableERC20Reentrant.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/test/ReserveToken.sol
+++ b/contracts/test/ReserveToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/test/ReserveTokenTest.sol
+++ b/contracts/test/ReserveTokenTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/SeedERC20ForceSendEther.sol
+++ b/contracts/test/SeedERC20ForceSendEther.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {SeedERC20} from "../seed/SeedERC20.sol";
 

--- a/contracts/test/SeedERC20Reentrant.sol
+++ b/contracts/test/SeedERC20Reentrant.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ReserveToken} from "./ReserveToken.sol";
 import {SeedERC20} from "../seed/SeedERC20.sol";

--- a/contracts/test/phased/PhasedScheduleTest.sol
+++ b/contracts/test/phased/PhasedScheduleTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Phased} from "../../phased/Phased.sol";
 

--- a/contracts/test/phased/PhasedTest.sol
+++ b/contracts/test/phased/PhasedTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Phased} from "../../phased/Phased.sol";
 

--- a/contracts/test/wrappers/RedeemableERC20ClaimEscrowWrapper.sol
+++ b/contracts/test/wrappers/RedeemableERC20ClaimEscrowWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 //solhint-disable-next-line max-line-length
 import {RedeemableERC20ClaimEscrow} from "../../escrow/RedeemableERC20ClaimEscrow.sol";

--- a/contracts/test/wrappers/TierByConstructionTest.sol
+++ b/contracts/test/wrappers/TierByConstructionTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ITier} from "../../tier/ITier.sol";
 import {TierByConstruction} from "../../tier/TierByConstruction.sol";

--- a/contracts/test/wrappers/TierReportTest.sol
+++ b/contracts/test/wrappers/TierReportTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity 0.8.10;
+pragma solidity =0.8.10;
 
 import {ITier} from "../../tier/ITier.sol";
 import {TierReport} from "../../tier/libraries/TierReport.sol";

--- a/contracts/test/wrappers/ValueTierTest.sol
+++ b/contracts/test/wrappers/ValueTierTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ValueTier} from "../../tier/ValueTier.sol";
 import {ITier} from "../../tier/ITier.sol";

--- a/contracts/tier/CombineTier.sol
+++ b/contracts/tier/CombineTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/tier/CombineTierFactory.sol
+++ b/contracts/tier/CombineTierFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import {Factory} from "../factory/Factory.sol";

--- a/contracts/tier/ERC20BalanceTier.sol
+++ b/contracts/tier/ERC20BalanceTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/tier/ERC20BalanceTierFactory.sol
+++ b/contracts/tier/ERC20BalanceTierFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 import "@openzeppelin/contracts/proxy/Clones.sol";
 
 import {Factory} from "../factory/Factory.sol";

--- a/contracts/tier/ERC20TransferTier.sol
+++ b/contracts/tier/ERC20TransferTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/tier/ERC20TransferTierFactory.sol
+++ b/contracts/tier/ERC20TransferTierFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 import "@openzeppelin/contracts/proxy/Clones.sol";
 
 import {Factory} from "../factory/Factory.sol";

--- a/contracts/tier/ITier.sol
+++ b/contracts/tier/ITier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.0;
 
 /// @title ITier
 /// @notice `ITier` is a simple interface that contracts can

--- a/contracts/tier/ReadOnlyTier.sol
+++ b/contracts/tier/ReadOnlyTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ITier} from "./ITier.sol";
 import {TierReport} from "./libraries/TierReport.sol";

--- a/contracts/tier/ReadWriteTier.sol
+++ b/contracts/tier/ReadWriteTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ITier} from "./ITier.sol";
 import "./libraries/TierConstants.sol";

--- a/contracts/tier/TierByConstruction.sol
+++ b/contracts/tier/TierByConstruction.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CAL
 
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {TierReport} from "./libraries/TierReport.sol";
 import {ITier} from "./ITier.sol";

--- a/contracts/tier/ValueTier.sol
+++ b/contracts/tier/ValueTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ITier} from "./ITier.sol";
 import "./libraries/TierConstants.sol";

--- a/contracts/tier/VerifyTier.sol
+++ b/contracts/tier/VerifyTier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/tier/VerifyTierFactory.sol
+++ b/contracts/tier/VerifyTierFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Verify} from "../verify/Verify.sol";
 import {Factory} from "../factory/Factory.sol";

--- a/contracts/tier/libraries/TierConstants.sol
+++ b/contracts/tier/libraries/TierConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// @title TierConstants
 /// @notice Constants for use with tier logic.

--- a/contracts/tier/libraries/TierReport.sol
+++ b/contracts/tier/libraries/TierReport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {ITier} from "../ITier.sol";
 import "./TierConstants.sol";

--- a/contracts/tier/libraries/TierwiseCombine.sol
+++ b/contracts/tier/libraries/TierwiseCombine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./TierReport.sol";

--- a/contracts/trust/Trust.sol
+++ b/contracts/trust/Trust.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {SaturatingMath} from "../math/SaturatingMath.sol";
 

--- a/contracts/trust/TrustFactory.sol
+++ b/contracts/trust/TrustFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/verify/Verify.sol
+++ b/contracts/verify/Verify.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/verify/VerifyFactory.sol
+++ b/contracts/verify/VerifyFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {Factory} from "../factory/Factory.sol";
 import {Verify} from "./Verify.sol";

--- a/contracts/verify/libraries/VerifyConstants.sol
+++ b/contracts/verify/libraries/VerifyConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// Summary statuses derived from a `State` by comparing the `xSince` times
 /// against a specific block number.

--- a/contracts/vm/RainVM.sol
+++ b/contracts/vm/RainVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 /// Everything required to evaluate and track the state of a rain script.
 /// As this is a struct it will be in memory when passed to `RainVM` and so

--- a/contracts/vm/libraries/VMState.sol
+++ b/contracts/vm/libraries/VMState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {State} from "../RainVM.sol";
 import "../../sstore2/SSTORE2.sol";

--- a/contracts/vm/ops/BlockOps.sol
+++ b/contracts/vm/ops/BlockOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {State} from "../RainVM.sol";
 

--- a/contracts/vm/ops/MathOps.sol
+++ b/contracts/vm/ops/MathOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {State} from "../RainVM.sol";
 

--- a/contracts/vm/ops/ThisOps.sol
+++ b/contracts/vm/ops/ThisOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {State} from "../RainVM.sol";
 

--- a/contracts/vm/ops/TierOps.sol
+++ b/contracts/vm/ops/TierOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity ^0.8.10;
+pragma solidity =0.8.10;
 
 import {State} from "../RainVM.sol";
 import "../../tier/libraries/TierReport.sol";

--- a/docusaurus/package-lock.json
+++ b/docusaurus/package-lock.json
@@ -11896,19 +11896,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -11925,12 +11912,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
     },
     "node_modules/space-separated-tokens": {
       "version": "1.1.5",
@@ -12902,17 +12883,6 @@
         "file-loader": {
           "optional": true
         }
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
-      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
-      "dependencies": {
-        "mime-db": "1.51.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/url-loader/node_modules/schema-utils": {
@@ -18846,11 +18816,6 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
       "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.0.tgz",
@@ -20399,43 +20364,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
-    },
-    "nanomatch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
-        }
-      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -22506,11 +22434,6 @@
         }
       }
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
@@ -23195,15 +23118,18 @@
         "loader-utils": "^2.0.0",
         "mime-types": "^2.1.27",
         "schema-utils": "^3.0.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
-      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "url-parse-lax": {


### PR DESCRIPTION
as per audit recommendation, locking to `=0.8.10` but i did leave interfaces open ended as `^0.8.0` as they may be included and consumed by external repos with their own versioning