### PR TITLE
verify hooks and multi add

### DIFF
--- a/contracts/sale/ISale.sol
+++ b/contracts/sale/ISale.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CAL
-pragma solidity =0.8.10;
+pragma solidity ^0.8.0;
 
 /// An `ISale` can be in one of 4 possible states and a linear progression is
 /// expected from an "in flight" status to an immutable definitive outcome.

--- a/contracts/test/VerifyCallbackTest.sol
+++ b/contracts/test/VerifyCallbackTest.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: CAL
+pragma solidity ^0.8.0;
+
+import {IVerifyCallback, Evidence} from "../verify/IVerifyCallback.sol";
+
+// Test contract for testing Verify hooks after adding, approving, banning or
+// removing an account.
+// All logic here is for testing purposes and should not necessarily be used in
+// an actual Verify callback contract.
+contract VerifyCallbackTest is IVerifyCallback {
+    /// Account => Boolean
+    mapping(address => bool) public additions;
+    mapping(address => bool) public approvals;
+    mapping(address => bool) public bans;
+    mapping(address => bool) public removals;
+
+    function afterAdd(
+        address adder_,
+        Evidence calldata evidence_
+    ) external virtual override {
+        require(adder_ != address(0), "0_ADDRESS");
+        require(!additions[evidence_.account], "PRIOR_ADD");
+        require(
+            keccak256(evidence_.data) == keccak256(bytes("Good")),
+            "BAD_EVIDENCE"
+        );
+        additions[evidence_.account] = true;
+    }
+
+    function afterApprove(
+        address approver_,
+        Evidence[] calldata evidences_
+    ) external virtual override {
+        require(approver_ != address(0), "0_ADDRESS");
+        for (uint256 index = 0; index < evidences_.length; index++) {
+            require(!approvals[evidences_[index].account], "PRIOR_APPROVE");
+            require(
+                keccak256(evidences_[index].data) == keccak256(bytes("Good")),
+                "BAD_EVIDENCE"
+            );
+            approvals[evidences_[index].account] = true;
+        }
+    }
+
+    function afterBan(
+        address banner_,
+        Evidence[] calldata evidences_
+    ) external virtual override {
+        require(banner_ != address(0), "0_ADDRESS");
+        for (uint256 index = 0; index < evidences_.length; index++) {
+            require(!bans[evidences_[index].account], "PRIOR_BAN");
+            require(
+                keccak256(evidences_[index].data) == keccak256(bytes("Good")),
+                "BAD_EVIDENCE"
+            );
+            bans[evidences_[index].account] = true;
+        }
+    }
+
+    function afterRemove(
+        address remover_,
+        Evidence[] calldata evidences_
+    ) external virtual override {
+        require(remover_ != address(0), "0_ADDRESS");
+        for (uint256 index = 0; index < evidences_.length; index++) {
+            require(!removals[evidences_[index].account], "PRIOR_REMOVE");
+            require(
+                keccak256(evidences_[index].data) == keccak256(bytes("Good")),
+                "BAD_EVIDENCE"
+            );
+            removals[evidences_[index].account] = true;
+        }
+    }
+}

--- a/contracts/tier/ReadWriteTier.sol
+++ b/contracts/tier/ReadWriteTier.sol
@@ -72,10 +72,10 @@ contract ReadWriteTier is ITier {
         // Emit this event for ITier.
         emit TierChange(msg.sender, account_, startTier_, endTier_, data_);
 
-        // Call the `_afterSetTier` hook to allow inheriting contracts
-        // to enforce requirements.
-        // The inheriting contract MUST `require` or otherwise
-        // enforce its needs to rollback a bad status change.
+        // Call the `_afterSetTier` hook to allow inheriting contracts to
+        // enforce requirements.
+        // The inheriting contract MUST `require` or otherwise enforce its
+        // needs to rollback a bad status change.
         _afterSetTier(account_, startTier_, endTier_, data_);
     }
 

--- a/contracts/verify/IVerifyCallback.sol
+++ b/contracts/verify/IVerifyCallback.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: CAL
+pragma solidity ^0.8.0;
+
+import {Evidence} from "./Verify.sol";
+
+/// Deployers of `Verify` contracts (e.g. via `VerifyFactory`) may want to
+/// apply additional processing and/or restrictions to each of the basic
+/// verification actions. Examples may be reading from onchain state or
+/// requiring token transfers to complete before allowing an add/approve to
+/// complete successfully. The reason this is an interface rather than
+/// implementors extending `Verify` directly is that it allows for more
+/// implementations to sit under a single `VerifyFactory` which in turn allows
+/// a more readily composed ecosystem of verified accounts.
+///
+/// There's no reentrancy concerns for external calls from the `Verify`
+/// contract to the `IVerifyCallback` contract because:
+/// - All the callbacks happen after state changes in `Verify`
+/// - All `Verify` actions are bound to the authority of the `msg.sender`
+/// The `IVerifyCallback` contract can and should rollback transactions if
+/// their restrictions/processing requirements are not met, but otherwise have
+/// no more authority over the `Verify` state than anon users.
+///
+/// The security model for platforms consuming `Verify` contracts is that they
+/// should index or otherwise filter children from the `VerifyFactory` down to
+/// those that also set a supported `IVerifyCallback` contract. The factory is
+/// completely agnostic to callback concerns and doesn't even require that a
+/// callback contract be set at all.
+interface IVerifyCallback {
+    /// Additional processing after an address has been added.
+    /// SHOULD revert/rollback transactions if processing fails.
+    /// @param adder_ The `msg.sender` in the `add`. Will be the addee.
+    /// @param evidence_ The evidence associated with the add.
+    function afterAdd(address adder_, Evidence calldata evidence_) external;
+
+    /// Additional processing after a batch of approvals.
+    /// SHOULD revert/rollback transactions if processing fails.
+    /// @param approver_ The `msg.sender` that authorized the approvals.
+    /// @param evidences_ All evidences associated with the approvals.
+    function afterApprove(address approver_, Evidence[] calldata evidences_)
+        external;
+
+    /// Additional processing after a batch of bannings.
+    /// SHOULD revert/rollback transactions if processing fails.
+    /// @param banner_ The `msg.sender` that authorized the bannings.
+    /// @param evidences_ All evidences associated with the bannings.
+    function afterBan(address banner_, Evidence[] calldata evidences_) external;
+
+    /// Additional processing after a batch of removals.
+    /// SHOULD revert/rollback transactions if processing fails.
+    /// @param remover_ The `msg.sender` that authorized the removals.
+    /// @param evidences_ All evidences associated with the removals.
+    function afterRemove(address remover_, Evidence[] calldata evidences_)
+        external;
+}

--- a/contracts/verify/Verify.sol
+++ b/contracts/verify/Verify.sol
@@ -331,13 +331,10 @@ contract Verify is AccessControl, Initializable {
         // requirements.
         // The inheriting contract MUST `require` or otherwise enforce its
         // needs to rollback a bad add.
-        _afterAdd(state_, evidence_);
+        _afterAdd(evidence_);
     }
 
-    function _afterAdd(State memory state_, Evidence memory evidence_)
-        internal
-        virtual
-    {}
+    function _afterAdd(Evidence memory evidence_) internal virtual {}
 
     /// An `APPROVER` can review added evidence and approve accounts.
     /// Typically many approvals would be submitted in a single call which is
@@ -390,9 +387,8 @@ contract Verify is AccessControl, Initializable {
             // This ensures that supporting evidence hits the logs for offchain
             // review.
             emit Approve(msg.sender, evidences_[i_]);
-
-            _afterApprove(state_, evidences_[i_]);
         }
+        _afterApprove(evidences_);
     }
 
     function requestApprove(Evidence[] calldata evidences_)
@@ -404,10 +400,7 @@ contract Verify is AccessControl, Initializable {
         }
     }
 
-    function _afterApprove(State memory state_, Evidence memory evidence_)
-        internal
-        virtual
-    {}
+    function _afterApprove(Evidence[] calldata evidences_) internal virtual {}
 
     /// A `BANNER` can ban an added OR approved account.
     /// @param evidences_ All evidence appropriate for all bans.
@@ -440,9 +433,8 @@ contract Verify is AccessControl, Initializable {
             // ensures that supporting evidence hits the logs for offchain
             // review.
             emit Ban(msg.sender, evidences_[i_]);
-
-            _afterBan(state_, evidences_[i_]);
         }
+        _afterBan(evidences_);
     }
 
     function requestBan(Evidence[] calldata evidences_) external onlyApproved {
@@ -451,10 +443,7 @@ contract Verify is AccessControl, Initializable {
         }
     }
 
-    function _afterBan(State memory state_, Evidence memory evidence_)
-        internal
-        virtual
-    {}
+    function _afterBan(Evidence[] calldata evidences_) internal virtual {}
 
     /// A `REMOVER` can scrub state mapping from an account.
     /// A malicious account MUST be banned rather than removed.
@@ -468,9 +457,8 @@ contract Verify is AccessControl, Initializable {
                 delete (states[evidences_[i_].account]);
             }
             emit Remove(msg.sender, evidences_[i_]);
-
-            _afterRemove(state_, evidences_[i_]);
         }
+        _afterRemove(evidences_);
     }
 
     function requestRemove(Evidence[] calldata evidences_)
@@ -482,8 +470,5 @@ contract Verify is AccessControl, Initializable {
         }
     }
 
-    function _afterRemove(State memory state_, Evidence memory evidence_)
-        internal
-        virtual
-    {}
+    function _afterRemove(Evidence[] calldata evidences_) internal virtual {}
 }

--- a/contracts/verify/VerifyFactory.sol
+++ b/contracts/verify/VerifyFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity =0.8.10;
 
 import {Factory} from "../factory/Factory.sol";
-import {Verify} from "./Verify.sol";
+import {Verify, VerifyConfig} from "./Verify.sol";
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 
@@ -27,9 +27,9 @@ contract VerifyFactory is Factory {
         override
         returns (address)
     {
-        address admin_ = abi.decode(data_, (address));
+        VerifyConfig memory config_ = abi.decode(data_, (VerifyConfig));
         address clone_ = Clones.clone(implementation);
-        Verify(clone_).initialize(admin_);
+        Verify(clone_).initialize(config_);
         return clone_;
     }
 

--- a/contracts/verify/VerifyFactory.sol
+++ b/contracts/verify/VerifyFactory.sol
@@ -37,9 +37,12 @@ contract VerifyFactory is Factory {
     /// Use original `Factory` `createChild` function signature if function
     /// parameters are already encoded.
     ///
-    /// @param admin_ `address` of the `Verify` admin.
+    /// @param config_ Initialization config for the new `Verify` child.
     /// @return New `Verify` child contract address.
-    function createChildTyped(address admin_) external returns (Verify) {
-        return Verify(this.createChild(abi.encode(admin_)));
+    function createChildTyped(VerifyConfig calldata config_)
+        external
+        returns (Verify)
+    {
+        return Verify(this.createChild(abi.encode(config_)));
     }
 }

--- a/test/Tier/VerifyTier.sol.ts
+++ b/test/Tier/VerifyTier.sol.ts
@@ -20,7 +20,10 @@ describe("VerifyTier", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      admin.address
+      {
+        admin: admin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify & Contract;
 
     const verifyTier = (await Util.verifyTierDeploy(

--- a/test/Verify/Verify.sol.ts
+++ b/test/Verify/Verify.sol.ts
@@ -22,12 +22,6 @@ enum Status {
   Banned,
 }
 
-enum Request {
-  APPROVE,
-  BAN,
-  REMOVE,
-}
-
 const APPROVER_ADMIN = ethers.utils.keccak256(
   ethers.utils.toUtf8Bytes("APPROVER_ADMIN")
 );
@@ -43,7 +37,7 @@ const BANNER_ADMIN = ethers.utils.keccak256(
 );
 const BANNER = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("BANNER"));
 
-describe("Verify", async function () {
+describe.only("Verify", async function () {
   it("should allow anyone to submit data to support a request to ban an account", async function () {
     this.timeout(0);
 
@@ -114,7 +108,7 @@ describe("Verify", async function () {
       async () =>
         verify
           .connect(signer2)
-          .request(Request.BAN, [
+          .requestBan([
             { account: signer1.address, data: evidenceBanReq },
           ]),
       "ONLY_APPROVED",
@@ -134,7 +128,7 @@ describe("Verify", async function () {
     const event0 = (await Util.getEventArgs(
       await verify
         .connect(signer2)
-        .request(Request.BAN, [
+        .requestBan([
           { account: signer1.address, data: evidenceBanReq },
         ]),
       "RequestBan",
@@ -218,7 +212,7 @@ describe("Verify", async function () {
       async () =>
         verify
           .connect(signer2)
-          .request(Request.REMOVE, [
+          .requestRemove([
             { account: signer1.address, data: evidenceRemoveReq },
           ]),
       "ONLY_APPROVED",
@@ -238,7 +232,7 @@ describe("Verify", async function () {
     const event0 = (await Util.getEventArgs(
       await verify
         .connect(signer2)
-        .request(Request.REMOVE, [
+        .requestRemove([
           { account: signer1.address, data: evidenceRemoveReq },
         ]),
       "RequestRemove",

--- a/test/Verify/Verify.sol.ts
+++ b/test/Verify/Verify.sol.ts
@@ -1134,7 +1134,7 @@ describe("Verify", async function () {
       defaultAdmin.address
     )) as Verify;
 
-    const evidenceAdd0 = hexlify([...Buffer.from("Evidence for add")]);
+    const evidenceAdd0 = hexlify([...Buffer.from("Evidence for add0")]);
 
     // signer1 submits evidence
     const event0 = (await Util.getEventArgs(
@@ -1147,10 +1147,16 @@ describe("Verify", async function () {
 
     const state0 = await verify.state(signer1.address);
 
-    const evidenceAdd1 = hexlify([...Buffer.from("Evidence for add override")]);
+    const evidenceAdd1 = hexlify([...Buffer.from("Evidence for add1")]);
 
     // signer1 can call `add()` again to submit new evidence, but it does not override state
-    await verify.connect(signer1).add(evidenceAdd1);
+    const event1 = (await Util.getEventArgs(
+      await verify.connect(signer1).add(evidenceAdd1),
+      "RequestApprove",
+      verify
+    )) as RequestApproveEvent["args"];
+    assert(event1.sender === signer1.address, "wrong sender in event1");
+    assert(event1.evidence.data === evidenceAdd1, "wrong data in event1");
 
     const state1 = await verify.state(signer1.address);
 
@@ -1164,8 +1170,16 @@ describe("Verify", async function () {
       );
     }
 
+    const evidenceAdd2 = hexlify([...Buffer.from("Evidence for add2")]);
+
     // another signer should be able to submit identical evidence
-    await verify.connect(signer2).add(evidenceAdd0);
+    const event2 = (await Util.getEventArgs(
+      await verify.connect(signer2).add(evidenceAdd2),
+      "RequestApprove",
+      verify
+    )) as RequestApproveEvent["args"];
+    assert(event2.sender === signer2.address, "wrong sender in event2");
+    assert(event2.evidence.data === evidenceAdd2, "wrong data in event2");
 
     // signer2 adding evidence should not wipe state for signer1
     const state2 = await verify.state(signer1.address);

--- a/test/Verify/Verify.sol.ts
+++ b/test/Verify/Verify.sol.ts
@@ -57,7 +57,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -157,7 +160,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -258,7 +264,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -334,7 +343,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -410,7 +422,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -482,7 +497,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     await verify.grantRole(await verify.APPROVER_ADMIN(), aprAdmin0.address);
@@ -528,7 +546,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     await verify.grantRole(await verify.APPROVER_ADMIN(), aprAdmin0.address);
@@ -612,7 +633,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -664,7 +688,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -813,7 +840,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -908,7 +938,7 @@ describe("Verify", async function () {
     const signers = await ethers.getSigners();
 
     await Util.assertError(
-      async () => await Util.verifyDeploy(signers[0], Util.zeroAddress),
+      async () => await Util.verifyDeploy(signers[0], { admin: Util.zeroAddress, callback: Util.zeroAddress }),
       "0_ACCOUNT",
       "wrongly constructed Verify with admin as zero address"
     );
@@ -932,7 +962,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin roles
@@ -1099,7 +1132,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     assert(
@@ -1131,7 +1167,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     const evidenceAdd0 = hexlify([...Buffer.from("Evidence for add0")]);
@@ -1205,7 +1244,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin role
@@ -1292,7 +1334,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin role
@@ -1387,7 +1432,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin role
@@ -1470,7 +1518,10 @@ describe("Verify", async function () {
 
     const verify = (await Util.verifyDeploy(
       signers[0],
-      defaultAdmin.address
+      {
+        admin: defaultAdmin.address,
+        callback: ethers.constants.AddressZero,
+      }
     )) as Verify;
 
     // defaultAdmin grants admin role


### PR DESCRIPTION
- adds hooks for contracts to extend Verify with additional requirements
- allows users to emit `RequestApprove` for themselves more than once to facilitate multi-step workflows
- refactors `request` to `requestX` function calls on verify