### PR TITLE
add base context for can transfer on flowerc20

### DIFF
--- a/contracts/flow/erc1155/FlowERC1155.sol
+++ b/contracts/flow/erc1155/FlowERC1155.sol
@@ -112,16 +112,21 @@ contract FlowERC1155 is ReentrancyGuard, FlowCommon, ERC1155 {
                 Evaluable memory evaluable_ = evaluable;
 
                 for (uint256 i_ = 0; i_ < ids_.length; i_++) {
-                    uint256[][] memory context_ = LibUint256Array
-                        .arrayFrom(
-                            uint(uint160(msg.sender)),
-                            uint(uint160(operator_)),
-                            uint256(uint160(from_)),
-                            uint256(uint160(to_)),
-                            ids_[i_],
-                            amounts_[i_]
-                        )
-                        .matrixFrom();
+                    uint256[][] memory context_;
+                    {
+                        context_ = LibContext.build(
+                                new uint256[][](0),
+                                // Transfer params are caller context.
+                                LibUint256Array.arrayFrom(
+                                    uint(uint160(operator_)),
+                                    uint256(uint160(from_)),
+                                    uint256(uint160(to_)),
+                                    ids_[i_],
+                                    amounts_[i_]
+                                ),
+                                new SignedContext[](0)
+                            );
+                    }
                     (
                         uint256[] memory stack_,
                         uint256[] memory kvs_

--- a/contracts/flow/erc20/FlowERC20.sol
+++ b/contracts/flow/erc20/FlowERC20.sol
@@ -113,14 +113,17 @@ contract FlowERC20 is ReentrancyGuard, FlowCommon, ERC20 {
             // CAN_TRANSFER will only restrict subsequent transfers.
             if (!(from_ == address(0) || to_ == address(0))) {
                 Evaluable memory evaluable_ = evaluable;
-                uint256[][] memory context_ = LibUint256Array
-                    .arrayFrom(
-                        uint(uint160(msg.sender)),
+                uint256[][] memory context_ = LibContext.build(
+                    new uint256[][](0),
+                    // The transfer params are caller context because the caller
+                    // is triggering the transfer.
+                    LibUint256Array.arrayFrom(
                         uint256(uint160(from_)),
                         uint256(uint160(to_)),
                         amount_
-                    )
-                    .matrixFrom();
+                    ),
+                    new SignedContext[](0)
+                );
                 (uint256[] memory stack_, uint256[] memory kvs_) = evaluable_
                     .interpreter
                     .eval(

--- a/contracts/flow/erc721/FlowERC721.sol
+++ b/contracts/flow/erc721/FlowERC721.sol
@@ -116,12 +116,6 @@ contract FlowERC721 is ReentrancyGuard, FlowCommon, ERC721 {
             // CAN_TRANSFER will only restrict subsequent transfers.
             if (!(from_ == address(0) || to_ == address(0))) {
                 Evaluable memory evaluable_ = evaluable;
-                uint256[] memory callerContext_ = LibUint256Array.arrayFrom(
-                    uint256(uint160(from_)),
-                    uint256(uint160(to_)),
-                    tokenId_,
-                    batchSize_
-                );
                 (uint256[] memory stack_, uint256[] memory kvs_) = evaluable_
                     .interpreter
                     .eval(
@@ -130,7 +124,13 @@ contract FlowERC721 is ReentrancyGuard, FlowCommon, ERC721 {
                         _dispatch(evaluable_.expression),
                         LibContext.build(
                             new uint256[][](0),
-                            callerContext_,
+                            // Transfer params are caller context.
+                            LibUint256Array.arrayFrom(
+                                uint256(uint160(from_)),
+                                uint256(uint160(to_)),
+                                tokenId_,
+                                batchSize_
+                            ),
                             new SignedContext[](0)
                         )
                     );

--- a/contracts/flow/erc721/FlowERC721.sol
+++ b/contracts/flow/erc721/FlowERC721.sol
@@ -128,8 +128,7 @@ contract FlowERC721 is ReentrancyGuard, FlowCommon, ERC721 {
                             LibUint256Array.arrayFrom(
                                 uint256(uint160(from_)),
                                 uint256(uint160(to_)),
-                                tokenId_,
-                                batchSize_
+                                tokenId_
                             ),
                             new SignedContext[](0)
                         )

--- a/contracts/interpreter/shared/Rainterpreter.sol
+++ b/contracts/interpreter/shared/Rainterpreter.sol
@@ -17,12 +17,12 @@ error UnexpectedOpMetaHash(bytes32 actualOpMeta);
 
 /// @dev Hash of the known store bytecode.
 bytes32 constant STORE_BYTECODE_HASH = bytes32(
-    0x36775b1934a6fbe8e789160ac6e44537bb466f94b40353e7352f50e012f2c20b
+    0xbc52db76e944bf5245c516990668f268c9d2f24dc3aa1b06b4f9d128914df383
 );
 
 /// @dev Hash of the known op meta.
 bytes32 constant OP_META_HASH = bytes32(
-    0xb53ed363fea1eea22c8d7e46f061b4c4b1fa19101f89a8341871d15edd290c51
+    0x2f3696e3d54355f65c5e7be86bbb8ea37687eacb0c91add9670a9c2f8ae0c7e4
 );
 
 /// All config required to construct a `Rainterpreter`.

--- a/contracts/interpreter/shared/Rainterpreter.sol
+++ b/contracts/interpreter/shared/Rainterpreter.sol
@@ -17,12 +17,12 @@ error UnexpectedOpMetaHash(bytes32 actualOpMeta);
 
 /// @dev Hash of the known store bytecode.
 bytes32 constant STORE_BYTECODE_HASH = bytes32(
-    0xbc52db76e944bf5245c516990668f268c9d2f24dc3aa1b06b4f9d128914df383
+    0x36775b1934a6fbe8e789160ac6e44537bb466f94b40353e7352f50e012f2c20b
 );
 
 /// @dev Hash of the known op meta.
 bytes32 constant OP_META_HASH = bytes32(
-    0x2f3696e3d54355f65c5e7be86bbb8ea37687eacb0c91add9670a9c2f8ae0c7e4
+    0xb53ed363fea1eea22c8d7e46f061b4c4b1fa19101f89a8341871d15edd290c51
 );
 
 /// All config required to construct a `Rainterpreter`.

--- a/test/Flow/FlowERC1155/flow.ts
+++ b/test/Flow/FlowERC1155/flow.ts
@@ -2085,4 +2085,239 @@ describe("FlowERC1155 flow tests", async function () {
       got       ${meBalance2}`
     );
   });
+
+  it("should utilize context in CAN_TRANSFER entrypoint", async () => {
+    const signers = await ethers.getSigners();
+    const deployer = signers[0];
+    const you = signers[1];
+
+    const erc20In = (await basicDeploy("ReserveToken18", {})) as ReserveToken18;
+    await erc20In.initialize();
+
+    const erc20Out = (await basicDeploy(
+      "ReserveToken18",
+      {}
+    )) as ReserveToken18;
+    await erc20Out.initialize();
+
+    const flowTransfer: FlowTransferStruct = {
+      native: [],
+      erc20: [
+        {
+          from: you.address,
+          to: "", // Contract address
+          token: erc20In.address,
+          amount: ethers.BigNumber.from(1 + eighteenZeros),
+        },
+        {
+          from: "", // Contract address
+          to: you.address,
+          token: erc20Out.address,
+          amount: ethers.BigNumber.from(2 + eighteenZeros),
+        },
+      ],
+      erc721: [],
+      erc1155: [],
+    };
+
+    const flowERC1155IO: FlowERC1155IOStruct = {
+      mints: [],
+      burns: [],
+      flow: flowTransfer,
+    };
+
+    const constants = [
+      RAIN_FLOW_SENTINEL,
+      RAIN_FLOW_ERC1155_SENTINEL,
+      1,
+      flowTransfer.erc20[0].token,
+      flowTransfer.erc20[0].amount,
+      flowTransfer.erc20[1].token,
+      flowTransfer.erc20[1].amount,
+      ethers.BigNumber.from(4 + eighteenZeros), // Bonus Amount
+      0
+    ];
+
+    const SENTINEL = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 0));
+    const SENTINEL_1155 = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 1));
+    const CAN_TRANSFER = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 2));
+
+    const FLOWTRANSFER_YOU_TO_ME_ERC20_TOKEN = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 3));
+    const FLOWTRANSFER_YOU_TO_ME_ERC20_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 4));
+
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_TOKEN = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 5));
+      const FLOWTRANSFER_ME_TO_YOU_ERC20_BASE_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 6));
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_BONUS_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 7));
+    const ZERO = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 8));
+
+    const sourceFlowIO = concat([
+      SENTINEL(), // ERC115 SKIP
+      SENTINEL(), // ERC721 SKIP
+      SENTINEL(), // ERC20 END
+      FLOWTRANSFER_YOU_TO_ME_ERC20_TOKEN(),
+      YOU(),
+      ME(),
+      FLOWTRANSFER_YOU_TO_ME_ERC20_AMOUNT(),
+      FLOWTRANSFER_ME_TO_YOU_ERC20_TOKEN(),
+      ME(),
+      YOU(),
+          // Setting a dynamic price which changes once a flow has been run
+          YOU(),
+          op(Opcode.GET),
+          ZERO(),
+        op(Opcode.GREATER_THAN),
+        FLOWTRANSFER_ME_TO_YOU_ERC20_BONUS_AMOUNT(),
+        FLOWTRANSFER_ME_TO_YOU_ERC20_BASE_AMOUNT(),
+      op(Opcode.EAGER_IF),
+      SENTINEL(), // NATIVE SKIP
+      SENTINEL_1155(),
+      SENTINEL_1155(),
+    ]);
+
+    const sources = [concat([
+      CAN_TRANSFER(),
+      // Setting a value for msg.sender.
+      // This will only be set _afterTokenTransfer
+        YOU(), // setting blocknumber for msg.sender as the key
+        op(Opcode.BLOCK_NUMBER),
+      op(Opcode.SET),
+    ])];
+
+    const expressionConfigStruct: ExpressionConfigStruct = {
+      sources,
+      constants,
+    };
+
+    const { flow } = await flowERC1155Deploy(deployer, flowERC1155Factory, {
+      uri: "F1155",
+      expressionConfig: expressionConfigStruct,
+      flows: [
+        {
+          sources: [sourceFlowIO],
+          constants,
+        },
+      ],
+    });
+
+    const flowInitialized = (await getEvents(
+      flow.deployTransaction,
+      "FlowInitialized",
+      flow
+    )) as FlowInitializedEvent["args"][];
+
+    const me = flow;
+
+    // Ensure parties hold enough ERC721
+    await erc20In.transfer(you.address, flowTransfer.erc20[0].amount);
+    await erc20Out.transfer(me.address, flowTransfer.erc20[1].amount);
+
+    await erc20In
+      .connect(you)
+      .approve(me.address, flowTransfer.erc20[0].amount);
+
+    const flowStruct = await flow
+      .connect(you)
+      .callStatic.flow(flowInitialized[0].evaluable, [1234], []);
+
+    compareStructs(
+      flowStruct,
+      fillEmptyAddressERC1155(flowERC1155IO, me.address)
+    );
+
+    const _txFlow = await flow
+      .connect(you)
+      .flow(flowInitialized[0].evaluable, [1234], []);
+
+    const meBalanceIn0 = await erc20In.balanceOf(me.address);
+    const meBalanceOut0 = await erc20Out.balanceOf(me.address);
+    const youBalanceIn0 = await erc20In.balanceOf(you.address);
+    const youBalanceOut0 = await erc20Out.balanceOf(you.address);
+
+    assert(
+      meBalanceIn0.eq(flowStruct.flow.erc20[0].amount),
+      `wrong balance for me (flow contract)
+      expected  ${flowStruct.flow.erc20[0].amount}
+      got       ${meBalanceIn0}`
+    );
+
+    assert(
+      meBalanceOut0.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${meBalanceOut0}`
+    );
+
+    assert(
+      youBalanceIn0.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${youBalanceIn0}`
+    );
+
+    assert(
+      youBalanceOut0.eq(flowStruct.flow.erc20[1].amount),
+      `wrong balance for you (signer1 contract)
+      expected  ${flowStruct.flow.erc20[1].amount}
+      got       ${youBalanceOut0}`
+    );
+
+
+    // Flowing for second time, this time a bonus amount should be transferred from contract to msg.sender
+    await erc20In.transfer(you.address, flowTransfer.erc20[0].amount);
+    await erc20Out.transfer(me.address, ethers.BigNumber.from(4 + eighteenZeros));
+
+    await erc20In
+      .connect(you)
+      .approve(me.address, flowTransfer.erc20[0].amount);
+
+    await flow
+      .connect(you)
+      .flow(flowInitialized[0].evaluable, [1234], []);
+
+    const meBalanceIn1 = await erc20In.balanceOf(me.address);
+    const meBalanceOut1 = await erc20Out.balanceOf(me.address);
+    const youBalanceIn1 = await erc20In.balanceOf(you.address);
+    const youBalanceOut1 = await erc20Out.balanceOf(you.address);
+
+    const expectedMeBalanceIn = (flowERC1155IO.flow.erc20[0].amount as BigNumber).mul(2);
+    const expectedMeBalanceOut = meBalanceOut1.add(meBalanceOut0);
+
+    assert(
+      meBalanceIn1.eq(expectedMeBalanceIn),
+      `wrong balance for me (flow contract)
+      expected  ${expectedMeBalanceIn}
+      got       ${meBalanceIn1}`
+    );
+
+    assert(
+      meBalanceOut1.eq(expectedMeBalanceOut),
+      `wrong balance for me (flow contract)
+      expected  ${expectedMeBalanceOut}
+      got       ${meBalanceOut1}`
+    );
+
+    assert(
+      youBalanceIn1.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${youBalanceIn1}`
+    );
+
+    assert(
+      youBalanceOut1.eq(await ethers.BigNumber.from(4 + eighteenZeros)),
+      `wrong balance for you (signer1 contract)
+      expected  ${ethers.BigNumber.from(4 + eighteenZeros)}
+      got       ${youBalanceOut1}`
+    );
+
+  });
 });

--- a/test/Flow/FlowERC20/flow.ts
+++ b/test/Flow/FlowERC20/flow.ts
@@ -2291,4 +2291,260 @@ describe("FlowERC20 flow tests", async function () {
       got       ${meBalance2}`
     );
   });
+
+  it("should utilize context in CAN_TRANSFER entrypoint", async () => {
+    const signers = await ethers.getSigners();
+    const deployer = signers[0];
+    const you = signers[1];
+
+    const erc20In = (await basicDeploy("ReserveToken18", {})) as ReserveToken18;
+    await erc20In.initialize();
+
+    const erc20Out = (await basicDeploy(
+      "ReserveToken18",
+      {}
+    )) as ReserveToken18;
+    await erc20Out.initialize();
+
+    const flowTransfer: FlowTransferStruct = {
+      native: [],
+      erc20: [
+        {
+          from: you.address,
+          to: "", // Contract address
+          token: erc20In.address,
+          amount: ethers.BigNumber.from(1 + eighteenZeros),
+        },
+        {
+          from: "", // Contract address
+          to: you.address,
+          token: erc20Out.address,
+          amount: ethers.BigNumber.from(2 + eighteenZeros),
+        },
+      ],
+      erc721: [],
+      erc1155: [],
+    };
+
+    const flowERC20IO: FlowERC20IOStruct = {
+      mints: [
+        {
+          account: you.address,
+          amount: ethers.BigNumber.from(20 + eighteenZeros),
+        },
+      ],
+      burns: [
+        {
+          account: you.address,
+          amount: ethers.BigNumber.from(10 + eighteenZeros),
+        },
+      ],
+      flow: flowTransfer,
+    };
+
+    const constants = [
+      RAIN_FLOW_SENTINEL,
+      RAIN_FLOW_ERC20_SENTINEL,
+      1,
+      flowERC20IO.mints[0].amount,
+      flowERC20IO.burns[0].amount,
+      flowTransfer.erc20[0].token,
+      flowTransfer.erc20[0].amount,
+      flowTransfer.erc20[1].token,
+      flowTransfer.erc20[1].amount, // Base Amount
+      ethers.BigNumber.from(4 + eighteenZeros), // Bonus Amount
+      0
+    ];
+
+    const SENTINEL = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 0));
+    const SENTINEL_ERC20 = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 1));
+
+    const CAN_TRANSFER = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 2));
+
+    const MINT_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 3));
+    const BURN_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 4));
+
+    const FLOWTRANSFER_YOU_TO_ME_ERC20_TOKEN = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 5));
+    const FLOWTRANSFER_YOU_TO_ME_ERC20_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 6));
+
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_TOKEN = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 7));
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_BASE_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 8));
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_BONUS_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 9));
+    const ZERO = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 10));
+
+    // prettier-ignore
+    const sourceFlowIO = concat([
+      SENTINEL(), // ERC115 SKIP
+      SENTINEL(), // ERC721 SKIP
+      SENTINEL(), // ERC20 END
+      FLOWTRANSFER_YOU_TO_ME_ERC20_TOKEN(),
+      YOU(),
+      ME(),
+      FLOWTRANSFER_YOU_TO_ME_ERC20_AMOUNT(),
+      FLOWTRANSFER_ME_TO_YOU_ERC20_TOKEN(),
+      ME(),
+      YOU(),
+      // Setting a dynamic price which changes once a flow has been run
+            YOU(),
+          op(Opcode.GET),
+          ZERO(),
+        op(Opcode.GREATER_THAN),
+        FLOWTRANSFER_ME_TO_YOU_ERC20_BONUS_AMOUNT(),
+        FLOWTRANSFER_ME_TO_YOU_ERC20_BASE_AMOUNT(),
+      op(Opcode.EAGER_IF),
+
+      SENTINEL(), // NATIVE SKIP
+      SENTINEL_ERC20(), // BURN END
+      YOU(),
+      BURN_AMOUNT(),
+      SENTINEL_ERC20(), // MINT END
+      YOU(),
+      MINT_AMOUNT(),
+    ]);
+
+    const sources = [concat([
+      CAN_TRANSFER(),
+      // Setting a value for msg.sender.
+      // This will only be set _afterTokenTransfer
+        YOU(), // setting blocknumber for msg.sender as the key
+        op(Opcode.BLOCK_NUMBER),
+      op(Opcode.SET),
+    ])];
+
+    const expressionConfigStruct: FlowERC20Config = {
+      name: "FlowERC20",
+      symbol: "F20",
+      expressionConfig: {
+        sources,
+        constants,
+      },
+      flows: [{ sources: [sourceFlowIO], constants }],
+    };
+
+    const { flow } = await flowERC20Deploy(
+      deployer,
+      flowERC20Factory,
+      expressionConfigStruct
+    );
+
+    const flowInitialized = (await getEvents(
+      flow.deployTransaction,
+      "FlowInitialized",
+      flow
+    )) as FlowInitializedEvent["args"][];
+
+    const me = flow;
+
+    // Ensure parties hold enough ERC20
+    await erc20In.transfer(you.address, flowTransfer.erc20[0].amount);
+    await erc20Out.transfer(me.address, flowTransfer.erc20[1].amount);
+
+    await erc20In
+      .connect(you)
+      .approve(me.address, flowTransfer.erc20[0].amount);
+
+    const flowStruct = await flow
+      .connect(you)
+      .callStatic.flow(flowInitialized[0].evaluable, [1234], []);
+
+    compareStructs(flowStruct, fillEmptyAddressERC20(flowERC20IO, me.address));
+
+    const _txFlow = await flow
+      .connect(you)
+      .flow(flowInitialized[0].evaluable, [1234], []);
+
+    const meBalanceIn0 = await erc20In.balanceOf(me.address);
+    const meBalanceOut0 = await erc20Out.balanceOf(me.address);
+    const youBalanceIn0 = await erc20In.balanceOf(you.address);
+    const youBalanceOut0 = await erc20Out.balanceOf(you.address);
+
+    assert(
+      meBalanceIn0.eq(await flowERC20IO.flow.erc20[0].amount),
+      `wrong balance for me (flow contract)
+      expected  ${flowERC20IO.flow.erc20[0].amount}
+      got       ${meBalanceIn0}`
+    );
+
+    assert(
+      meBalanceOut0.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${meBalanceOut0}`
+    );
+
+    assert(
+      youBalanceIn0.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${youBalanceIn0}`
+    );
+
+    assert(
+      youBalanceOut0.eq(await flowERC20IO.flow.erc20[1].amount),
+      `wrong balance for you (signer1 contract)
+      expected  ${flowERC20IO.flow.erc20[1].amount}
+      got       ${youBalanceOut0}`
+    );
+
+    // Flowing for second time, this time a bonus amount should be transferred from contract to msg.sender
+    await erc20In.transfer(you.address, flowTransfer.erc20[0].amount);
+    await erc20Out.transfer(me.address, ethers.BigNumber.from(4 + eighteenZeros));
+
+    await erc20In
+      .connect(you)
+      .approve(me.address, flowTransfer.erc20[0].amount);
+
+    await flow
+      .connect(you)
+      .flow(flowInitialized[0].evaluable, [1234], []);
+
+    const meBalanceIn1 = await erc20In.balanceOf(me.address);
+    const meBalanceOut1 = await erc20Out.balanceOf(me.address);
+    const youBalanceIn1 = await erc20In.balanceOf(you.address);
+    const youBalanceOut1 = await erc20Out.balanceOf(you.address);
+
+    const expectedMeBalanceIn = (flowERC20IO.flow.erc20[0].amount as BigNumber).mul(2);
+    const expectedMeBalanceOut = meBalanceOut1.add(meBalanceOut0);
+
+    assert(
+      meBalanceIn1.eq(expectedMeBalanceIn),
+      `wrong balance for me (flow contract)
+      expected  ${expectedMeBalanceIn}
+      got       ${meBalanceIn1}`
+    );
+
+    assert(
+      meBalanceOut1.eq(expectedMeBalanceOut),
+      `wrong balance for me (flow contract)
+      expected  ${expectedMeBalanceOut}
+      got       ${meBalanceOut1}`
+    );
+
+    assert(
+      youBalanceIn1.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${youBalanceIn1}`
+    );
+
+    assert(
+      youBalanceOut1.eq(await ethers.BigNumber.from(4 + eighteenZeros)),
+      `wrong balance for you (signer1 contract)
+      expected  ${ethers.BigNumber.from(4 + eighteenZeros)}
+      got       ${youBalanceOut1}`
+    );
+
+  });
+
 });

--- a/test/Flow/FlowERC721/flow.ts
+++ b/test/Flow/FlowERC721/flow.ts
@@ -2242,4 +2242,240 @@ describe("FlowERC721 flow tests", async function () {
       got       ${meBalance2}`
     );
   });
+
+  it("should utilize context in CAN_TRANSFER entrypoint", async () => {
+    const signers = await ethers.getSigners();
+    const deployer = signers[0];
+    const you = signers[1];
+
+    const erc20In = (await basicDeploy("ReserveToken18", {})) as ReserveToken18;
+    await erc20In.initialize();
+
+    const erc20Out = (await basicDeploy(
+      "ReserveToken18",
+      {}
+    )) as ReserveToken18;
+    await erc20Out.initialize();
+
+    const flowTransfer: FlowTransferStruct = {
+      native: [],
+      erc20: [
+        {
+          from: you.address,
+          to: "", // Contract address
+          token: erc20In.address,
+          amount: ethers.BigNumber.from(1 + eighteenZeros),
+        },
+        {
+          from: "", // Contract address
+          to: you.address,
+          token: erc20Out.address,
+          amount: ethers.BigNumber.from(2 + eighteenZeros),
+        },
+      ],
+      erc721: [],
+      erc1155: [],
+    };
+
+    const flowERC721IO: FlowERC721IOStruct = {
+      mints: [],
+      burns: [],
+      flow: flowTransfer,
+    };
+
+    const constants = [
+      RAIN_FLOW_SENTINEL,
+      RAIN_FLOW_ERC721_SENTINEL,
+      1,
+      flowTransfer.erc20[0].token,
+      flowTransfer.erc20[0].amount,
+      flowTransfer.erc20[1].token,
+      flowTransfer.erc20[1].amount, // Base Amount
+      ethers.BigNumber.from(4 + eighteenZeros), // Bonus Amount
+      0
+    ];
+
+    const SENTINEL = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 0));
+    const SENTINEL_721 = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 1));
+    const CAN_TRANSFER = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 2));
+    const FLOWTRANSFER_YOU_TO_ME_ERC20_TOKEN = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 3));
+    const FLOWTRANSFER_YOU_TO_ME_ERC20_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 4));
+
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_TOKEN = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 5));
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_BASE_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 6));
+    const FLOWTRANSFER_ME_TO_YOU_ERC20_BONUS_AMOUNT = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 7));
+    const ZERO = () =>
+      op(Opcode.READ_MEMORY, memoryOperand(MemoryType.Constant, 8));
+
+    const sourceFlowIO = concat([
+      SENTINEL(), // ERC115 SKIP
+      SENTINEL(), // ERC721 SKIP
+      SENTINEL(), // ERC20 END
+      FLOWTRANSFER_YOU_TO_ME_ERC20_TOKEN(),
+      YOU(),
+      ME(),
+      FLOWTRANSFER_YOU_TO_ME_ERC20_AMOUNT(),
+      FLOWTRANSFER_ME_TO_YOU_ERC20_TOKEN(),
+      ME(),
+      YOU(),
+      // Setting a dynamic price which changes once a flow has been run
+            YOU(),
+          op(Opcode.GET),
+          ZERO(),
+        op(Opcode.GREATER_THAN),
+        FLOWTRANSFER_ME_TO_YOU_ERC20_BONUS_AMOUNT(),
+        FLOWTRANSFER_ME_TO_YOU_ERC20_BASE_AMOUNT(),
+      op(Opcode.EAGER_IF),
+
+      SENTINEL(), // NATIVE SKIP
+      SENTINEL_721(),
+      SENTINEL_721(),
+    ]);
+
+    const sources = [concat([
+      CAN_TRANSFER(),
+      // Setting a value for msg.sender.
+      // This will only be set _afterTokenTransfer
+        YOU(), // setting blocknumber for msg.sender as the key
+        op(Opcode.BLOCK_NUMBER),
+      op(Opcode.SET),
+    ])];
+
+
+    const expressionConfigStruct: ExpressionConfigStruct = {
+      sources,
+      constants,
+    };
+
+    const { flow } = await flowERC721Deploy(deployer, flowERC721Factory, {
+      name: "FlowERC721",
+      symbol: "F721",
+      expressionConfig: expressionConfigStruct,
+      flows: [
+        {
+          sources: [sourceFlowIO],
+          constants,
+        },
+      ],
+    });
+
+    const flowInitialized = (await getEvents(
+      flow.deployTransaction,
+      "FlowInitialized",
+      flow
+    )) as FlowInitializedEvent["args"][];
+
+    const me = flow;
+
+    // Ensure parties hold enough ERC721
+    await erc20In.transfer(you.address, flowTransfer.erc20[0].amount);
+    await erc20Out.transfer(me.address, flowTransfer.erc20[1].amount);
+
+    await erc20In
+      .connect(you)
+      .approve(me.address, flowTransfer.erc20[0].amount);
+
+    const flowStruct = await flow
+      .connect(you)
+      .callStatic.flow(flowInitialized[0].evaluable, [1234], []);
+
+    compareStructs(
+      flowStruct,
+      fillEmptyAddressERC721(flowERC721IO, me.address)
+    );
+
+    const _txFlow = await flow
+      .connect(you)
+      .flow(flowInitialized[0].evaluable, [1234], []);
+
+    const meBalanceIn0 = await erc20In.balanceOf(me.address);
+    const meBalanceOut0 = await erc20Out.balanceOf(me.address);
+    const youBalanceIn0 = await erc20In.balanceOf(you.address);
+    const youBalanceOut0 = await erc20Out.balanceOf(you.address);
+
+    assert(
+      meBalanceIn0.eq(await flowERC721IO.flow.erc20[0].amount),
+      `wrong balance for me (flow contract)
+      expected  ${flowStruct.flow.erc20[0].amount}
+      got       ${meBalanceIn0}`
+    );
+
+    assert(
+      meBalanceOut0.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${meBalanceOut0}`
+    );
+
+    assert(
+      youBalanceIn0.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${youBalanceIn0}`
+    );
+
+    assert(
+      youBalanceOut0.eq(await flowERC721IO.flow.erc20[1].amount),
+      `wrong balance for you (signer1 contract)
+      expected  ${flowStruct.flow.erc20[1].amount}
+      got       ${youBalanceOut0}`
+    );
+
+
+    // Flowing for second time, this time a bonus amount should be transferred from contract to msg.sender
+    await erc20In.transfer(you.address, flowTransfer.erc20[0].amount);
+    await erc20Out.transfer(me.address, ethers.BigNumber.from(4 + eighteenZeros));
+
+    await erc20In
+      .connect(you)
+      .approve(me.address, flowTransfer.erc20[0].amount);
+
+    await flow
+      .connect(you)
+      .flow(flowInitialized[0].evaluable, [1234], []);
+
+    const meBalanceIn1 = await erc20In.balanceOf(me.address);
+    const meBalanceOut1 = await erc20Out.balanceOf(me.address);
+    const youBalanceIn1 = await erc20In.balanceOf(you.address);
+    const youBalanceOut1 = await erc20Out.balanceOf(you.address);
+
+    const expectedMeBalanceIn = (flowERC721IO.flow.erc20[0].amount as BigNumber).mul(2);
+    const expectedMeBalanceOut = meBalanceOut1.add(meBalanceOut0);
+
+    assert(
+      meBalanceIn1.eq(expectedMeBalanceIn),
+      `wrong balance for me (flow contract)
+      expected  ${expectedMeBalanceIn}
+      got       ${meBalanceIn1}`
+    );
+
+    assert(
+      meBalanceOut1.eq(expectedMeBalanceOut),
+      `wrong balance for me (flow contract)
+      expected  ${expectedMeBalanceOut}
+      got       ${meBalanceOut1}`
+    );
+
+    assert(
+      youBalanceIn1.eq(BigNumber.from(0)),
+      `wrong balance for me (flow contract)
+      expected  ${0}
+      got       ${youBalanceIn1}`
+    );
+
+    assert(
+      youBalanceOut1.eq(await ethers.BigNumber.from(4 + eighteenZeros)),
+      `wrong balance for you (signer1 contract)
+      expected  ${ethers.BigNumber.from(4 + eighteenZeros)}
+      got       ${youBalanceOut1}`
+    );
+  });
 });


### PR DESCRIPTION
- standardises context building for transfers in all flow contracts
- removes batch size from 721 context as it is always 1 currently